### PR TITLE
fix: set correct peerDependency version for @ngxs/store

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -19,7 +19,7 @@
   "sideEffects": true,
   "peerDependencies": {
     "@angular/core": ">=7.0.0",
-    "@ngxs/store": ">=5.0.0",
+    "@ngxs/store": ">=3.6.2",
     "rxjs": ">=6.5.2"
   },
   "ngPackage": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The set peerDependency with `@ngxs/store>=5.0.0` does not exist and throws an error

Issue Number: https://github.com/ngxs-labs/attach-action/issues/19


## What is the new behavior?
The peerDependency is set to a version that was current at the release of this package (`3.6.2`)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
